### PR TITLE
Memory leak fix in SignalSenderKeyName

### DIFF
--- a/libsignal-protocol-swift.xcodeproj/project.pbxproj
+++ b/libsignal-protocol-swift.xcodeproj/project.pbxproj
@@ -2580,7 +2580,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_INCLUDE_PATHS = "${SRCROOT}/libsignal-protocol-swift/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2638,7 +2638,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = "${SRCROOT}/libsignal-protocol-swift/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -2669,7 +2669,7 @@
 				PRODUCT_NAME = SignalProtocol;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2697,7 +2697,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swift";
 				PRODUCT_NAME = SignalProtocol;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -2716,7 +2716,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swiftTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -2735,7 +2735,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "christophhagen.libsignal-protocol-swiftTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -2771,7 +2771,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -2805,7 +2805,7 @@
 				PRODUCT_NAME = SignalProtocol;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -2837,7 +2837,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.3;
 			};
@@ -2870,7 +2870,7 @@
 				PRODUCT_NAME = SignalProtocol;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.3;
 			};
@@ -2905,7 +2905,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 4.3;
 			};
@@ -2939,7 +2939,7 @@
 				PRODUCT_NAME = SignalProtocol;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 4.3;
 			};

--- a/libsignal-protocol-swift.xcodeproj/project.pbxproj
+++ b/libsignal-protocol-swift.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		320E84BE2875BF780086E66A /* Signature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320E84BD2875BF780086E66A /* Signature.swift */; };
+		320E84BF2875BF780086E66A /* Signature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320E84BD2875BF780086E66A /* Signature.swift */; };
+		320E84C02875BF780086E66A /* Signature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320E84BD2875BF780086E66A /* Signature.swift */; };
+		320E84C12875BF780086E66A /* Signature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320E84BD2875BF780086E66A /* Signature.swift */; };
+		320E84C32875C3E50086E66A /* SignatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320E84C22875C3E50086E66A /* SignatureTests.swift */; };
 		CE048C342036F890002AB31C /* SignalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE048C332036F890002AB31C /* SignalError.swift */; };
 		CE048C352036F890002AB31C /* SignalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE048C332036F890002AB31C /* SignalError.swift */; };
 		CE048C362036F890002AB31C /* SignalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE048C332036F890002AB31C /* SignalError.swift */; };
@@ -814,6 +819,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		320E84BD2875BF780086E66A /* Signature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signature.swift; sourceTree = "<group>"; };
+		320E84C22875C3E50086E66A /* SignatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureTests.swift; sourceTree = "<group>"; };
 		A060453525ED4AF10063391D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		A060458525ED4D760063391D /* SignalProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalProtocolTests.swift; sourceTree = "<group>"; };
 		A060458725ED4D760063391D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1123,6 +1130,7 @@
 			children = (
 				CEEDDA7D203663D4000A0A98 /* TestImplementation */,
 				CE1F0C43203467B3003F1C04 /* CipherTests.swift */,
+				320E84C22875C3E50086E66A /* SignatureTests.swift */,
 				CE409A15203AE9C900B7D6A7 /* GroupCipherTests.swift */,
 				CE409A17203AEA3100B7D6A7 /* TestHelper.swift */,
 				CEFD541C203B7EF300EAE28D /* FingerprintTests.swift */,
@@ -1422,6 +1430,7 @@
 				CEE3452820350AF5001FE63B /* SignalAddress.swift */,
 				CE048C332036F890002AB31C /* SignalError.swift */,
 				CEE3455F20351612001FE63B /* SignalSenderKeyName.swift */,
+				320E84BD2875BF780086E66A /* Signature.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -1985,6 +1994,7 @@
 				CE1F0DF120346A19003F1C04 /* gen_labelset.c in Sources */,
 				CE1F0DDD20346A19003F1C04 /* gen_x.c in Sources */,
 				CECF5C9A2035B2BA004A4D28 /* Signal.swift in Sources */,
+				320E84BE2875BF780086E66A /* Signature.swift in Sources */,
 				CE1F0D6D20346A19003F1C04 /* fe_sq2.c in Sources */,
 				CE1F0EFD20346A19003F1C04 /* open.c in Sources */,
 				CE7345B72037AC3E0011C67B /* KeyStoreWrapper.swift in Sources */,
@@ -2093,6 +2103,7 @@
 				CE409A18203AEA3100B7D6A7 /* TestHelper.swift in Sources */,
 				CEEDDA83203666FE000A0A98 /* TestSenderKeyStore.swift in Sources */,
 				CEFD541D203B7EF300EAE28D /* FingerprintTests.swift in Sources */,
+				320E84C32875C3E50086E66A /* SignatureTests.swift in Sources */,
 				CE409A16203AE9C900B7D6A7 /* GroupCipherTests.swift in Sources */,
 				CEEDDA7F203663EB000A0A98 /* TestIdentityStore.swift in Sources */,
 				CEEDDA8720366963000A0A98 /* TestSignedPrekeyStore.swift in Sources */,
@@ -2133,6 +2144,7 @@
 				CE1F0DF220346A19003F1C04 /* gen_labelset.c in Sources */,
 				CE1F0DDE20346A19003F1C04 /* gen_x.c in Sources */,
 				CE1F0D6E20346A19003F1C04 /* fe_sq2.c in Sources */,
+				320E84BF2875BF780086E66A /* Signature.swift in Sources */,
 				CE048C3A2036FDB1002AB31C /* SessionPreKeyBundle.swift in Sources */,
 				CE1F0EFE20346A19003F1C04 /* open.c in Sources */,
 				CE7345B82037AC3E0011C67B /* KeyStoreWrapper.swift in Sources */,
@@ -2265,6 +2277,7 @@
 				CE1F0DF320346A19003F1C04 /* gen_labelset.c in Sources */,
 				CE1F0DDF20346A19003F1C04 /* gen_x.c in Sources */,
 				CE1F0D6F20346A19003F1C04 /* fe_sq2.c in Sources */,
+				320E84C02875BF780086E66A /* Signature.swift in Sources */,
 				CE048C382036FDB1002AB31C /* SessionPreKeyBundle.swift in Sources */,
 				CE1F0EFF20346A19003F1C04 /* open.c in Sources */,
 				CE7345B92037AC3E0011C67B /* KeyStoreWrapper.swift in Sources */,
@@ -2397,6 +2410,7 @@
 				CE1F0DF420346A19003F1C04 /* gen_labelset.c in Sources */,
 				CE1F0DE020346A19003F1C04 /* gen_x.c in Sources */,
 				CE1F0D7020346A19003F1C04 /* fe_sq2.c in Sources */,
+				320E84C12875BF780086E66A /* Signature.swift in Sources */,
 				CE048C392036FDB1002AB31C /* SessionPreKeyBundle.swift in Sources */,
 				CE1F0F0020346A19003F1C04 /* open.c in Sources */,
 				CE7345BA2037AC3E0011C67B /* KeyStoreWrapper.swift in Sources */,

--- a/libsignal-protocol-swift.xcodeproj/project.pbxproj
+++ b/libsignal-protocol-swift.xcodeproj/project.pbxproj
@@ -1774,9 +1774,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE1F0C49203467B3003F1C04 /* Build configuration list for PBXNativeTarget "libsignal-protocol-swift iOS" */;
 			buildPhases = (
+				CE1F0C32203467B3003F1C04 /* Headers */,
 				CE1F0C30203467B3003F1C04 /* Sources */,
 				CE1F0C31203467B3003F1C04 /* Frameworks */,
-				CE1F0C32203467B3003F1C04 /* Headers */,
 				CE1F0C33203467B3003F1C04 /* Resources */,
 			);
 			buildRules = (
@@ -1810,9 +1810,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE1F0C5920346830003F1C04 /* Build configuration list for PBXNativeTarget "libsignal-protocol-swift macOS" */;
 			buildPhases = (
+				CE1F0C5120346830003F1C04 /* Headers */,
 				CE1F0C4F20346830003F1C04 /* Sources */,
 				CE1F0C5020346830003F1C04 /* Frameworks */,
-				CE1F0C5120346830003F1C04 /* Headers */,
 				CE1F0C5220346830003F1C04 /* Resources */,
 			);
 			buildRules = (
@@ -1828,9 +1828,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE1F0C662034685B003F1C04 /* Build configuration list for PBXNativeTarget "libsignal-protocol-swift tvOS" */;
 			buildPhases = (
+				CE1F0C5E2034685B003F1C04 /* Headers */,
 				CE1F0C5C2034685B003F1C04 /* Sources */,
 				CE1F0C5D2034685B003F1C04 /* Frameworks */,
-				CE1F0C5E2034685B003F1C04 /* Headers */,
 				CE1F0C5F2034685B003F1C04 /* Resources */,
 			);
 			buildRules = (
@@ -1846,9 +1846,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE1F0C7320346875003F1C04 /* Build configuration list for PBXNativeTarget "libsignal-protocol-swift watchOS" */;
 			buildPhases = (
+				CE1F0C6B20346875003F1C04 /* Headers */,
 				CE1F0C6920346875003F1C04 /* Sources */,
 				CE1F0C6A20346875003F1C04 /* Frameworks */,
-				CE1F0C6B20346875003F1C04 /* Headers */,
 				CE1F0C6C20346875003F1C04 /* Resources */,
 			);
 			buildRules = (

--- a/libsignal-protocol-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/libsignal-protocol-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
+++ b/libsignal-protocol-swift/Misc/SignalSenderKeyName.swift
@@ -44,6 +44,10 @@ public final class SignalSenderKeyName {
         address.pointee = signal_protocol_sender_key_name(group_id: groupPointer, group_id_len: count, sender: sender.signalAddress.pointee)
     }
 
+    deinit {
+        address.deallocate()
+    }
+
     /**
      Create an a sender key name from a pointer to a libsignal-protocol-c address.
      - parameter address: The pointer to the address

--- a/libsignal-protocol-swift/Misc/Signature.swift
+++ b/libsignal-protocol-swift/Misc/Signature.swift
@@ -94,6 +94,6 @@ public struct Signature {
         if verifyRes < 0 {
             return .failure(.verifyError(SignalError(value: verifyRes)))
         }
-        return .success(verifyRes == 0)
+        return .success(verifyRes == 1)
     }
 }

--- a/libsignal-protocol-swift/Misc/Signature.swift
+++ b/libsignal-protocol-swift/Misc/Signature.swift
@@ -1,0 +1,61 @@
+//
+//  Signature.swift
+//  libsignal-protocol-swift
+//
+//  Created by Benjamin Garrigues on 06/07/2022.
+//  Copyright © 2022 User. All rights reserved.
+//
+
+import Foundation
+import SignalModule
+
+public struct Signature {
+    public enum SignatureError: Error {
+        case signError(SignalError)
+        case nilSignatureBuffer
+        case keyDecodeError(SignalError)
+    }
+
+    // privatekey: Taken from KeyPair
+    public static func sign(payload: Data, withPrivateKey privateKey: Data) -> Result<Data, SignatureError> {
+
+        // Convert private key to [UInt8]
+        let privateBuffer = privateKey.signalBuffer
+        defer { signal_buffer_free(privateBuffer) }
+        let privLength = signal_buffer_len(privateBuffer)
+        let privData = signal_buffer_data(privateBuffer)!
+        var privKey: OpaquePointer? = nil
+        let keyDecodeResult = withUnsafeMutablePointer(to: &privKey) {
+            curve_decode_private_point($0, privData, privLength, Signal.context)
+        }
+        guard keyDecodeResult == 0 else {
+            return .failure(.keyDecodeError(SignalError(value: keyDecodeResult)))
+        }
+        var signatureBuf: OpaquePointer? = nil
+        let signResult = withUnsafeMutablePointer(to: &signatureBuf) { signatureBufPtr in
+            return payload.withUnsafeBytes {
+                return curve_calculate_signature(
+                    Signal.context,
+                    signatureBufPtr,
+                    privKey,
+                    $0,
+                    payload.count)
+            }
+        }
+
+        guard signResult == 0 else {
+            return .failure(.signError(SignalError(value: signResult)))
+        }
+        guard let signatureBuf = signatureBuf else {
+            return .failure(.nilSignatureBuffer)
+        }
+        defer { signal_buffer_free(signatureBuf) }
+
+        return .success(Data(signalBuffer: signatureBuf))
+    }
+
+
+    public static func verify(signature: Data, for payload: Data, withPublicKey publicKey: Data) -> Bool {
+        return false
+    }
+}

--- a/libsignal-protocol-swift/Misc/Signature.swift
+++ b/libsignal-protocol-swift/Misc/Signature.swift
@@ -45,7 +45,7 @@ public struct Signature {
                     signatureBufPtr,
                     privKey,
                     payloadRawBufPtr.baseAddress,
-                    payloadRawBufPtr.count)
+                    payload.count) // NSData may overallocate, so we don't want the buffer size, only the "useful" part.
             }
         }
 
@@ -85,9 +85,9 @@ public struct Signature {
             return payload.withUnsafeBytes { (payloadPtr: UnsafeRawBufferPointer) in
                 return curve_verify_signature(pubKey,
                                               payloadPtr.baseAddress,
-                                              payloadPtr.count,
+                                              payload.count, // NSData may overallocate, so we don't want the buffer size, only the "useful" part
                                               signaturePtr.baseAddress,
-                                              signaturePtr.count)
+                                              signature.count) // NSData may overallocate, so we don't want the buffer size, only the "useful" part
             }
         }
 

--- a/libsignal-protocol-swift/SignalProtocol.h
+++ b/libsignal-protocol-swift/SignalProtocol.h
@@ -14,5 +14,5 @@ FOUNDATION_EXPORT double libsignal_protocol_swiftVersionNumber;
 //! Project version string for libsignal_protocol_swift.
 FOUNDATION_EXPORT const unsigned char libsignal_protocol_swiftVersionString[];
 
-#include "setup.h"
+#include "Setup/setup.h"
 

--- a/libsignal-protocol-swiftTests/SignatureTests.swift
+++ b/libsignal-protocol-swiftTests/SignatureTests.swift
@@ -68,5 +68,14 @@ class SignatureTests: XCTestCase {
             XCTFail("verify  failure : \(failure)")
         }
 
+        // verify with a different public key
+        let otherKeyPair = try! Signal.generateIdentityKeyPair()
+        switch Signature.verify(signature: signature, for: payload, withPublicKey: otherKeyPair.publicKey){
+        case .success(let success):
+            XCTAssertFalse(success)
+        case .failure(let failure):
+            XCTFail("verify  failure : \(failure)")
+        }
+
     }
 }

--- a/libsignal-protocol-swiftTests/SignatureTests.swift
+++ b/libsignal-protocol-swiftTests/SignatureTests.swift
@@ -1,0 +1,30 @@
+//
+//  SignatureTests.swift
+//  libsignal-protocol-swiftTests
+//
+//  Created by Benjamin Garrigues on 06/07/2022.
+//  Copyright © 2022 User. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import SignalProtocol
+
+
+class SignatureTests: XCTestCase {
+    func testSignPayload() {
+        guard let ownStore = setupStore(makeKeys: true) else {
+            XCTFail("Could not create store")
+            return
+        }
+        guard let identity = ownStore.identityKeyStore.identityKeyPair() else {
+            XCTFail("no identity keypair found")
+            return
+        }
+
+        let payload: Data = "test".data(using: .utf8)!
+        let signature = Signature.sign(payload: payload, withPrivateKey: identity.privateKey)
+        XCTAssertTrue(Signature.verify(signature: signature, for: payload, withPublicKey: identity.publicKey))
+        XCTAssertFalse(Signature.verify(signature: signature, for: payload, withPublicKey: identity.privateKey))
+    }
+}

--- a/libsignal-protocol-swiftTests/SignatureTests.swift
+++ b/libsignal-protocol-swiftTests/SignatureTests.swift
@@ -42,7 +42,25 @@ class SignatureTests: XCTestCase {
             XCTFail("unexpected outcome for verify : \(res)")
         }
 
+        // use the wrong key to verify
+        let resPrivate = Signature.verify(signature: signature, for: payload, withPublicKey: identity.privateKey)
+        switch resPrivate {
+        case .failure(.keyDecodeError(let error)):
+            XCTAssertEqual(error, SignalError.invalidKey)
+        break
+        default:
+            XCTFail("unexpected verify with wrong key outcome : \(resPrivate)")
+        }
 
+        // verify a different payload
+        switch Signature.verify(signature: signature, for: "test2".data(using: .utf8)!, withPublicKey: identity.publicKey){
+        case .success(let success):
+            XCTAssertFalse(success)
+        case .failure(let failure):
+            XCTFail("verify  failure : \(failure)")
+        }
+
+        // good verify
         switch Signature.verify(signature: signature, for: payload, withPublicKey: identity.publicKey){
         case .success(let success):
             XCTAssertTrue(success)
@@ -50,13 +68,5 @@ class SignatureTests: XCTestCase {
             XCTFail("verify  failure : \(failure)")
         }
 
-        res = Signature.verify(signature: signature, for: payload, withPublicKey: identity.privateKey)
-        switch res {
-        case .failure(.keyDecodeError(let error)):
-            XCTAssertEqual(error, SignalError.invalidKey)
-        break
-        default:
-            XCTFail("unexpected verify with wrong key outcome : \(res)")
-        }
     }
 }


### PR DESCRIPTION
address property was not properly deallocated, leading to memory leak. 

![Capture d’écran 2022-10-17 à 15 04 12](https://user-images.githubusercontent.com/8861304/196184354-1c507c3a-b673-48d4-9d06-a27446527d57.png)
